### PR TITLE
Fix function label handling

### DIFF
--- a/c_to_z80_compiler.py
+++ b/c_to_z80_compiler.py
@@ -59,8 +59,9 @@ class CToZ80Compiler:
                 continue
             elif item['type'] == 'function_start':
                 func_name = item['name']
-                # Gewone functie label:
-                functions_section.append(f"{func_name}:")
+                # Use :: for known pointer table/global functions
+                label_suffix = '::' if self.is_pointer_table_function(func_name) else ':'
+                functions_section.append(f"{func_name}{label_suffix}")
                 in_function = True
             elif item['type'] == 'function_end':
                 in_function = False
@@ -150,6 +151,9 @@ class CToZ80Compiler:
                 function_name = self.extract_function_name(line)
                 processed.append({'type': 'function_start', 'name': function_name})
                 i += 1
+                # Skip duplicate label lines immediately following the function definition
+                if i < len(lines) and lines[i].strip() == f"{function_name}:":
+                    i += 1
                 continue
             
             # Look ahead for pointer table patterns after function ends
@@ -1120,6 +1124,7 @@ class CToZ80Compiler:
             'PlayerStepOutFromDoor',  # This IS a pointer table function
             '_EndNPCMovementScript',   # This IS a pointer table function
             'SetEnemyTrainerToStayAndFaceAnyDirection'  # This IS a pointer table function
+            ,'ClearVariablesOnEnterMap'
         }
         
         return func_name in pointer_functions


### PR DESCRIPTION
## Summary
- update function label generation so known pointer table functions use `::`
- skip duplicate labels right after the function definition to avoid extra labels
- allow `ClearVariablesOnEnterMap` to be treated as a pointer table/global function

## Testing
- `python -m py_compile c_to_z80_compiler.py`
- `python c_to_z80_compiler.py > /tmp/compile.log`
- `python compare_assembly.py > /tmp/compare.log`

------
https://chatgpt.com/codex/tasks/task_e_684057d03554833394164c8074800a70